### PR TITLE
Implemented Settings Page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,15 @@
             "integrity": "sha512-QVqJywrQWwJzoDCXibZkXrg+T91hNCTCN9qznmum4FSewL0MUtaHotv7Zc/D4scvEwpwWnKx5vpw4CY14V4OYw==",
             "dev": true
         },
+        "@vue/test-utils": {
+            "version": "1.0.0-beta.20",
+            "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.0.0-beta.20.tgz",
+            "integrity": "sha1-70UFNBuALz3hwGs8uGUTeMhzcfo=",
+            "dev": true,
+            "requires": {
+                "lodash": "^4.17.4"
+            }
+        },
         "abab": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
         "vue": "^2.5.11"
     },
     "devDependencies": {
+        "@vue/test-utils": "^1.0.0-beta.20",
         "@handsontable/vue": "^2.0.0",
         "avoriaz": "^6.3.0",
         "babel-core": "^6.26.0",

--- a/src/views/settings.vue
+++ b/src/views/settings.vue
@@ -1,13 +1,72 @@
 <template>
 
 <div id="settings">
-    <h1>Settings</h1>
+    <h1>User Information</h1>
+    <h3>{{this.name}}</h3>
+    <h3>{{this.photo}}</h3>
+    <div v-if="display">
+        <input v-model="temp_name" placeholder="New Name">
+        <input v-model="temp_photo" placeholder="New Photo">
+        <button v-on:click="saveData(true)"><h4>Edit Information</h4></button>
+        <button v-on:click="saveData(false)"><h4>Cancel</h4></button>
+    </div>
+
+    <div v-else>
+        <button v-on:click="display=true"><h4>Edit Information</h4></button>
+    </div>
 </div>
 
 </template>
 
 <script>
+import generate_query_string from "./components/generate_query_string";
 export default {
-    name: "settings"
+    data: function() {
+        return {
+            name: null,
+            photo: null,
+            temp_name: null,
+            temp_photo: null,
+            display: false
+        };
+    },
+    created: function() {
+        this.getData();
+    },
+    methods: {
+        /**
+         * Getting user information for user.
+         */
+        getData: function() {
+            let url = {
+                what: "user_info",
+                user_id: this.$route.params.user_id
+            };
+            fetch("get_info.php?" + generate_query_string(url))
+                .then(res => res.json())
+                .then(data => {
+                    this.name = data.DATA[0].name;
+                    this.photo = data.DATA[0].photo;
+                })
+                .catch(err => {
+                    this.$emit("error", err.toString());
+                });
+        },
+        /**
+         * If save is true, values entered within fields are saved as new
+         * name and photo if not null.
+         *
+         * @param save Set true if data within temporary fields should be saved
+         */
+        saveData: function(save) {
+            if (save) {
+                this.name = this.temp_name != null && this.temp_name;
+                this.photo = this.temp_photo != null && this.temp_photo;
+            }
+            this.temp_name = null;
+            this.temp_photo = null;
+            this.display = false;
+        }
+    }
 };
 </script>

--- a/src/views/settings.vue
+++ b/src/views/settings.vue
@@ -60,8 +60,9 @@ export default {
          */
         saveData: function(save) {
             if (save) {
-                this.name = this.temp_name != null && this.temp_name;
-                this.photo = this.temp_photo != null && this.temp_photo;
+                this.name = this.temp_name != null ? this.temp_name : this.name;
+                this.photo =
+                    this.temp_photo != null ? this.temp_photo : this.photo;
             }
             this.temp_name = null;
             this.temp_photo = null;

--- a/test/settings.spec.js
+++ b/test/settings.spec.js
@@ -1,0 +1,82 @@
+// This is the mocha testing file for settings component
+const chai = require("chai");
+const expect = chai.expect;
+import Settings from "./../src/views/settings.vue";
+import { shallowMount, createLocalVue } from "@vue/test-utils";
+import VueRouter from "vue-router";
+
+const localVue = createLocalVue();
+localVue.use(VueRouter);
+const route = [
+    {
+        path: "user_id/admin0/settings",
+        component: Settings
+    }
+];
+const router = new VueRouter({ router: route });
+
+describe("Test Settings Component", function() {
+    let wrapper;
+    beforeEach(function() {
+        wrapper = shallowMount(Settings, {
+            localVue,
+            router
+        });
+    });
+
+    it("Only display and temporary data should be mutated`", function() {
+        wrapper.setData({
+            name: "name",
+            photo: "photo",
+            temp_name: "No Change Name",
+            temp_photo: "No Change Photo"
+        });
+        wrapper.vm.saveData(false);
+        expect(wrapper.vm.name).to.be.equal("name");
+        expect(wrapper.vm.photo).to.be.equal("photo");
+        expect(wrapper.vm.display).to.be.equal(false);
+    });
+
+    it("Name and photo should be set to temp photo and name field`", function() {
+        wrapper.setData({
+            name: "name",
+            photo: "photo",
+            temp_name: "Change Name",
+            temp_photo: "Change Photo"
+        });
+        wrapper.vm.saveData(true);
+        expect(wrapper.vm.name).to.be.equal("Change Name");
+        expect(wrapper.vm.photo).to.be.equal("Change Photo");
+        expect(wrapper.vm.temp_name).to.be.equal(null);
+        expect(wrapper.vm.temp_photo).to.be.equal(null);
+        expect(wrapper.vm.display).to.be.equal(false);
+    });
+
+    it("Only name should be set to temp name field`", function() {
+        wrapper.setData({
+            name: "name",
+            photo: "photo",
+            temp_name: "Change Name"
+        });
+        wrapper.vm.saveData(true);
+        expect(wrapper.vm.name).to.be.equal("Change Name");
+        expect(wrapper.vm.photo).to.be.equal("photo");
+        expect(wrapper.vm.temp_name).to.be.equal(null);
+        expect(wrapper.vm.temp_photo).to.be.equal(null);
+        expect(wrapper.vm.display).to.be.equal(false);
+    });
+
+    it("Only photo should be set to temp photo field`", function() {
+        wrapper.setData({
+            name: "name",
+            photo: "photo",
+            temp_photo: "Change Photo"
+        });
+        wrapper.vm.saveData(true);
+        expect(wrapper.vm.name).to.be.equal("name");
+        expect(wrapper.vm.photo).to.be.equal("Change Photo");
+        expect(wrapper.vm.temp_name).to.be.equal(null);
+        expect(wrapper.vm.temp_photo).to.be.equal(null);
+        expect(wrapper.vm.display).to.be.equal(false);
+    });
+});


### PR DESCRIPTION
fixes #73 
- Display user's name and photo
- Button to enable edit mode
- Once in edit mode, can edit photo and name
- Option to save or cancel changes