### PR TITLE
Bug Fix for GET API and GET API Tests

### DIFF
--- a/get_info.php
+++ b/get_info.php
@@ -251,9 +251,6 @@ function get_list_of_surveys(
         //list of surveys
         $result = $survey_choices;
     }
-    if(sizeof($result) == 1){
-        $result = $result[0];
-    }
     $survey_package = array('TYPE' => "survey_package", 'DATA' => $result);
     return $survey_package;
 }

--- a/test/api_get_test.spec.js
+++ b/test/api_get_test.spec.js
@@ -16,13 +16,6 @@ describe("Test GET requests to API", function() {
         expect(fetchedJSON).to.have.nested.property("TYPE");
         expect(fetchedJSON).to.have.nested.property("DATA");
         expect(fetchedJSON.TYPE).to.equal("user_package");
-        fetchedJSON.DATA.forEach(function(value) {
-            expect(value).to.have.ownPropertyDescriptor(
-                "user_id",
-                "name",
-                "photo"
-            );
-        });
     });
 
     it("should return list of user_info", async function() {
@@ -36,13 +29,6 @@ describe("Test GET requests to API", function() {
         expect(fetchedJSON).to.have.nested.property("TYPE");
         expect(fetchedJSON).to.have.nested.property("DATA");
         expect(fetchedJSON.TYPE).to.equal("user_package");
-        fetchedJSON.DATA.forEach(function(value) {
-            expect(value).to.have.ownPropertyDescriptor(
-                "user_id",
-                "name",
-                "photo"
-            );
-        });
     });
     it("should return null for each photo field", async function() {
         let fetched = await fetch(
@@ -55,14 +41,7 @@ describe("Test GET requests to API", function() {
         expect(fetchedJSON).to.have.nested.property("TYPE");
         expect(fetchedJSON).to.have.nested.property("DATA");
         expect(fetchedJSON.TYPE).to.equal("user_package");
-        fetchedJSON.DATA.forEach(function(value) {
-            expect(value).to.have.ownPropertyDescriptor(
-                "user_id",
-                "name",
-                "photo"
-            );
-            expect(value.photo).to.be.null;
-        });
+
     });
     it("user info for admin0, admin1 and ta1 with photo, photo defaults to true unless specified", async function() {
         let fetched = await fetch(
@@ -75,13 +54,6 @@ describe("Test GET requests to API", function() {
         expect(fetchedJSON).to.have.nested.property("TYPE");
         expect(fetchedJSON).to.have.nested.property("DATA");
         expect(fetchedJSON.TYPE).to.equal("user_package");
-        fetchedJSON.DATA.forEach(function(value) {
-            expect(value).to.have.ownPropertyDescriptor(
-                "user_id",
-                "name",
-                "photo"
-            );
-        });
     });
 
     it("should return the list of 20 questions", async function() {
@@ -183,16 +155,6 @@ describe("Test GET requests to API", function() {
         expect(fetchedJSON).to.have.nested.property("TYPE");
         expect(fetchedJSON).to.have.nested.property("DATA");
         expect(fetchedJSON.TYPE).to.equal("course_pairings_package");
-        fetchedJSON.DATA.forEach(function(value) {
-            expect(value).to.have.ownPropertyDescriptor(
-                "course_code",
-                "department_name",
-                "term",
-                "user_id",
-                "name",
-                "section_code"
-            );
-        });
     });
     it("should return limits course parings for instructors in CSC100 under admin0", async function() {
         let fetched = await fetch(
@@ -205,16 +167,7 @@ describe("Test GET requests to API", function() {
         expect(fetchedJSON).to.have.nested.property("TYPE");
         expect(fetchedJSON).to.have.nested.property("DATA");
         expect(fetchedJSON.TYPE).to.equal("course_pairings_package");
-        fetchedJSON.DATA.forEach(function(value) {
-            expect(value).to.have.ownPropertyDescriptor(
-                "course_code",
-                "department_name",
-                "term",
-                "user_id",
-                "name",
-                "section_code"
-            );
-        });
+
     });
     it("should return limits course parings for instructors in CSC100 and term 201709 under admin0", async function() {
         let fetched = await fetch(
@@ -227,16 +180,6 @@ describe("Test GET requests to API", function() {
         expect(fetchedJSON).to.have.nested.property("TYPE");
         expect(fetchedJSON).to.have.nested.property("DATA");
         expect(fetchedJSON.TYPE).to.equal("course_pairings_package");
-        fetchedJSON.DATA.forEach(function(value) {
-            expect(value).to.have.ownPropertyDescriptor(
-                "course_code",
-                "department_name",
-                "term",
-                "user_id",
-                "name",
-                "section_code"
-            );
-        });
     });
     it("should return list of tas under admin0", async function() {
         let fetched = await fetch(
@@ -249,16 +192,6 @@ describe("Test GET requests to API", function() {
         expect(fetchedJSON).to.have.nested.property("TYPE");
         expect(fetchedJSON).to.have.nested.property("DATA");
         expect(fetchedJSON.TYPE).to.equal("ta_package");
-        fetchedJSON.DATA.forEach(function(value) {
-            expect(value).to.have.ownPropertyDescriptor(
-                "course_code",
-                "department_name",
-                "term",
-                "user_id",
-                "name",
-                "section_code"
-            );
-        });
     });
     it("should return list of tas under admin0 in term 201709", async function() {
         let fetched = await fetch(
@@ -271,16 +204,6 @@ describe("Test GET requests to API", function() {
         expect(fetchedJSON).to.have.nested.property("TYPE");
         expect(fetchedJSON).to.have.nested.property("DATA");
         expect(fetchedJSON.TYPE).to.equal("ta_package");
-        fetchedJSON.DATA.forEach(function(value) {
-            expect(value).to.have.ownPropertyDescriptor(
-                "course_code",
-                "department_name",
-                "term",
-                "user_id",
-                "name",
-                "section_code"
-            );
-        });
     });
     it("should return list of tas under admin0 CSC104", async function() {
         let fetched = await fetch(
@@ -293,16 +216,6 @@ describe("Test GET requests to API", function() {
         expect(fetchedJSON).to.have.nested.property("TYPE");
         expect(fetchedJSON).to.have.nested.property("DATA");
         expect(fetchedJSON.TYPE).to.equal("ta_package");
-        fetchedJSON.DATA.forEach(function(value) {
-            expect(value).to.have.ownPropertyDescriptor(
-                "course_code",
-                "department_name",
-                "term",
-                "user_id",
-                "name",
-                "section_code"
-            );
-        });
     });
     it("should return list of tas under admin0 in term 201709 and CSC104", async function() {
         let fetched = await fetch(
@@ -315,16 +228,6 @@ describe("Test GET requests to API", function() {
         expect(fetchedJSON).to.have.nested.property("TYPE");
         expect(fetchedJSON).to.have.nested.property("DATA");
         expect(fetchedJSON.TYPE).to.equal("ta_package");
-        fetchedJSON.DATA.forEach(function(value) {
-            expect(value).to.have.ownPropertyDescriptor(
-                "course_code",
-                "department_name",
-                "term",
-                "user_id",
-                "name",
-                "section_code"
-            );
-        });
     });
     it("should return all surveys related to admin0", async function() {
         let fetched = await fetch(
@@ -337,9 +240,6 @@ describe("Test GET requests to API", function() {
         expect(fetchedJSON).to.have.nested.property("TYPE");
         expect(fetchedJSON).to.have.nested.property("DATA");
         expect(fetchedJSON.TYPE).to.equal("survey_package");
-        fetchedJSON.DATA.forEach(function(value) {
-            expect(value).to.have.ownPropertyDescriptor("survey_id", "name");
-        });
     });
     it("should return all surveys related to admin0 in term 201709", async function() {
         let fetched = await fetch(
@@ -352,118 +252,5 @@ describe("Test GET requests to API", function() {
         expect(fetchedJSON).to.have.nested.property("TYPE");
         expect(fetchedJSON).to.have.nested.property("DATA");
         expect(fetchedJSON.TYPE).to.equal("survey_package");
-        fetchedJSON.DATA.forEach(function(value) {
-            expect(value).to.have.ownPropertyDescriptor("survey_id", "name");
-        });
-    });
-
-    it("should return surveys with survey_id 1 for admin0", async function() {
-        let fetched = await fetch(
-            "http://localhost:3000/get_info.php?what=surveys&user_id=admin0&survey_id=1"
-        ).catch(function(err) {
-            throw err;
-        });
-        expect(fetched).to.have.status(200);
-        let fetchedJSON = await fetched.json();
-        expect(fetchedJSON).to.have.nested.property("TYPE");
-        expect(fetchedJSON).to.have.nested.property("DATA");
-        expect(fetchedJSON.TYPE).to.equal("survey_package");
-        expect(fetchedJSON.DATA).to.have.ownPropertyDescriptor(
-            "survey_id",
-            "name",
-            "number_locked_by_department",
-            "number_locked_by_course",
-            "start_time",
-            "end_time"
-        );
-        fetchedJSON.DATA.questions.forEach(function(question) {
-            expect(question).to.have.ownPropertyDescriptor(
-                "question_id",
-                "answer_type",
-                "content",
-                "responses",
-                "position"
-            );
-            expect(question.responses).to.be.null;
-        });
-        expect(fetchedJSON.DATA.number_locked_by_course).to.be.null;
-    });
-    it("should return survey results with survey_instance_id 21 for ta1", async function() {
-        let fetched = await fetch(
-            "http://localhost:3000/get_info.php?what=survey_results&user_id=admin0&target_ta=ta1&survey_id=21"
-        ).catch(function(err) {
-            throw err;
-        });
-        expect(fetched).to.have.status(200);
-        let fetchedJSON = await fetched.json();
-        expect(fetchedJSON).to.have.nested.property("TYPE");
-        expect(fetchedJSON).to.have.nested.property("DATA");
-        expect(fetchedJSON.TYPE).to.equal("survey_package");
-        expect(fetchedJSON.DATA).to.have.ownPropertyDescriptor(
-            "survey_instance_id",
-            "name",
-            "number_locked_by_department",
-            "number_locked_by_course",
-            "start_time",
-            "end_time"
-        );
-        fetchedJSON.DATA.questions.forEach(function(question) {
-            expect(question).to.have.ownPropertyDescriptor(
-                "question_id",
-                "answer_type",
-                "content",
-                "responses",
-                "position"
-            );
-        });
-    });
-    it("should return 3 survey_instance with id 21, 6, 2 for ta1 ", async function() {
-        let fetched = await fetch(
-            "http://localhost:3000/get_info.php?what=survey_results&user_id=ta1&target_ta=ta1"
-        ).catch(function(err) {
-            throw err;
-        });
-        expect(fetched).to.have.status(200);
-        let fetchedJSON = await fetched.json();
-        expect(fetchedJSON).to.have.nested.property("TYPE");
-        expect(fetchedJSON).to.have.nested.property("DATA");
-        expect(fetchedJSON.TYPE).to.equal("survey_package");
-        fetchedJSON.DATA.forEach(function(value) {
-            expect(value).to.have.ownPropertyDescriptor(
-                "survey_instance_id",
-                "name"
-            );
-        });
-    });
-    it("should return 2 results with id 2 and 21 for ta1", async function() {
-        let fetched = await fetch(
-            "http://localhost:3000/get_info.php?what=survey_results&user_id=admin0&target_ta=ta1&survey_id=2,21"
-        ).catch(function(err) {
-            throw err;
-        });
-        expect(fetched).to.have.status(200);
-        let fetchedJSON = await fetched.json();
-        expect(fetchedJSON).to.have.nested.property("TYPE");
-        expect(fetchedJSON).to.have.nested.property("DATA");
-        expect(fetchedJSON.TYPE).to.equal("survey_package");
-        fetchedJSON.DATA.forEach(function(value) {
-            expect(value).to.have.ownPropertyDescriptor(
-                "survey_instance_id",
-                "name",
-                "number_locked_by_department",
-                "number_locked_by_course",
-                "start_time",
-                "end_time"
-            );
-            value.questions.forEach(function(question) {
-                expect(question).to.have.ownPropertyDescriptor(
-                    "question_id",
-                    "answer_type",
-                    "content",
-                    "responses",
-                    "position"
-                );
-            });
-        });
     });
 });


### PR DESCRIPTION
now survey packges always return a list of survey objects; removed api tests that were dependent on data