### PR TITLE
GET API bug fix

### DIFF
--- a/get_query_generators.php
+++ b/get_query_generators.php
@@ -324,7 +324,7 @@ function gen_query_get_choices()
 {
     //Get the choices based on $choice
     $choices = "SELECT *
-    FROM Choices
+    FROM choices
     WHERE choices_id = :choices_id;";
 
     return $choices;


### PR DESCRIPTION
This PR deals the data returned to survey results_page to get the survey data needed for summarizing survey stats for TAs. This is done by:
- when requesting surveys of a particular user without specifying survey_id, instead of returning a list of survey_ids to be selected from then making another API call based on the survey selected. All survey_data is returned for the particular user, instead of having to make an additional API call for the list of surveys being returned to a particular user.