### PR TITLE
Update "branch first and then update" in survey update API

### DIFF
--- a/post_info.php
+++ b/post_info.php
@@ -810,10 +810,18 @@ function handle_survey_update(
     $level_choices_id = $orig_survey_info[$level_choices];
     $choices = $data[$table]["choices"];
 
-    if ($level_choices_id == null && $choices != null) {
+    if ($level_choices_id == null) {
         // in this case the choices were null. We need to first create
         // the a row in the `choices` table and then make a row
         // in the `*_survey_choices` table.
+
+        // If $chioces == null, we should set all the choices to
+        // null. This is a placeholder so that we know that this
+        // survey has been edited.
+        if ($choices == null) {
+            $choices = [null, null, null, null, null, null];
+        }
+
         $sql = gen_query_insert_new_choices();
         execute_sql($sql, [
             "choice1" => $choices[0],

--- a/query_utils.php
+++ b/query_utils.php
@@ -117,7 +117,14 @@ function get_survey_choices($survey_id, $survey_table_row = null, $conn = null)
     }
     // We need to get all the level choices so they can be rendered
     // into the final survey.
-    $nulls = [null, null, null, null, null, null];
+    $nulls = [
+        "choice1" => null,
+        "choice2" => null,
+        "choice3" => null,
+        "choice4" => null,
+        "choice5" => null,
+        "choice6" => null,
+    ];
     $choices_array = [[-1, -1, -1, -1, -1, -1]];
     foreach (
         [


### PR DESCRIPTION
Old behaviour: 
    When the "survey_update" does "branch first and then update" and there is nothing set of the `survey_choices` in the user level if the user sends the request data with `survey_choices` being null. 
(Problem of this: This will cause the newly branched survey being branched again the next time the user sends the "survey update" request on this survey.  This unexpected behaviour will keep repeating to generate more unneeded surveys if the `survey_choices` attribute in the user's request is always null. )

New behaviour: 
    When the "survey_update" does "branch first and then update" and the user sends the request data with `survey_choices` being null, there will be new `choices` and new `survey_choices` instance generated for the branched survey with all the 6 choices being null.