### PR TITLE
Sanitize start time

### DIFF
--- a/src/views/components/response_components/launch-modal.vue
+++ b/src/views/components/response_components/launch-modal.vue
@@ -104,12 +104,23 @@ export default {
             // number of days between dates
             this.duration = Math.floor((close - open) / 86400000);
 
-            this.date =
-                open.getFullYear() +
-                "-" +
-                (open.getMonth() + 1) +
-                "-" +
-                open.getDate();
+            // If open date is in past, set open date to today
+            let now = new Date();
+            if (open < now) {
+                this.date =
+                    now.getFullYear() +
+                    "-" +
+                    ("0" + (now.getMonth() + 1)).slice(-2) +
+                    "-" +
+                    ("0" + now.getDate()).slice(-2);
+            } else {
+                this.date =
+                    open.getFullYear() +
+                    "-" +
+                    (open.getMonth() + 1) +
+                    "-" +
+                    open.getDate();
+            }
         },
         /**
          * Function launches survey for selected time and duration

--- a/src/views/components/response_components/survey_display.vue
+++ b/src/views/components/response_components/survey_display.vue
@@ -32,8 +32,8 @@
                     <v-list-tile-action-text v-if="survey_package.override_token">Override Token:</v-list-tile-action-text>
                     <v-list-tile-action-text v-if="survey_package.override_token">{{survey_package.override_token}}</v-list-tile-action-text>
                 </v-list-tile-action>
-                <v-list-tile-action class="pa-2">
-                        <v-list-tile-action-text v-if="closed_date">
+                <v-list-tile-action v-if="is_instance && closed_date">
+                        <v-list-tile-action-text>
                                 Closed:
                         </v-list-tile-action-text>
                         <v-list-tile-action-text>


### PR DESCRIPTION
fixes #229 

- Start date on launch modal defaults to today if default start time in database has passed.

- Remove closed text if not a survey instance