### PR TITLE
Launch survey without cloning & split templates/customized surveys

### DIFF
--- a/php/post_info.php
+++ b/php/post_info.php
@@ -71,7 +71,12 @@ try {
                     break;
             }
         case 'launch_survey':
-            handle_launch_survey($params["survey_id"], $params["user_id"]);
+            handle_launch_survey(
+                $params["survey_id"],
+                $params["user_id"],
+                array_get($params, "survey_open"),
+                array_get($params, "survey_close")
+            );
 
         default:
             throw new Exception("'what' attribute '$what' not valid!");
@@ -206,6 +211,8 @@ function get_unique_override_token()
 function handle_launch_survey(
     $survey_id,
     $user_id,
+    $survey_open = null,
+    $survey_close = null,
     $course_code = "UofT",
     $section_code = "Tutorial",
     $term = null
@@ -244,6 +251,13 @@ function handle_launch_survey(
         $term
     );
 
+    if ($survey_open == null) {
+        $survey_open = $survey_package["default_survey_open"];
+    }
+    if ($survey_close == null) {
+        $survey_close = $survey_package["default_survey_close"];
+    }
+
     $sql =
         "INSERT INTO survey_instances (survey_id, choices_id, user_association_id, override_token, survey_open, survey_close, viewable_by_others, name) " .
         "VALUES (:survey_id, :choices_id, :user_association_id, :override_token, :survey_open, :survey_close, :viewable_by_others, :name);";
@@ -252,8 +266,8 @@ function handle_launch_survey(
         'choices_id' => $new_choices_id,
         'user_association_id' => $user_association_id,
         'override_token' => $override_token,
-        'survey_open' => $survey_package["default_survey_open"],
-        'survey_close' => $survey_package["default_survey_close"],
+        'survey_open' => $survey_open,
+        'survey_close' => $survey_close,
         'viewable_by_others' => 0,
         'name' => $survey_package['name']
     ];

--- a/src/views/components/survey_display.vue
+++ b/src/views/components/survey_display.vue
@@ -26,7 +26,7 @@
 <v-expansion-panel class="survey-display">
 
     <v-expansion-panel-content hide-actions lazy>
-            <v-list-tile slot="header">
+            <v-list-tile slot="header" :class="[color, 'lighten-5']">
                 <v-list-tile-action>
                         <v-icon class="mx-2">keyboard_arrow_down</v-icon>
                 </v-list-tile-action>
@@ -71,7 +71,7 @@
 import ResponseSummary from "./response_summary.vue";
 export default {
     name: "SurveyDisplay",
-    props: ["survey_package", "is_instance"],
+    props: ["survey_package", "is_instance", "color"],
     methods: {
         buttonClick: function(e, action) {
             // prevent the expansion-panel from expanding.


### PR DESCRIPTION
	Now the open and close time for a survey can be set on launch,
	which means surveys do not need to be cloned before launching.

	The surveys view has been split into "Survey Templates" and
	"Customized Surveys" to make it less confusing to the user
	which surveys they have edited.